### PR TITLE
Redesign card action links to match header control link style

### DIFF
--- a/script.js
+++ b/script.js
@@ -567,32 +567,33 @@ if (!locationLink) {
   const attributionEl = document.createElement('p');
   attributionEl.innerHTML = `<strong>Attribution:</strong> ${attribution}`;
 
-  // Create link to item
-  const locationLinkEl = document.createElement('a');
-  locationLinkEl.href = locationLink;
-  locationLinkEl.textContent = 'View Item';
-  locationLinkEl.target = '_blank';
+  // Create link container (like control-links)
+const cardLinks = document.createElement('div');
+cardLinks.className = 'card-links';
 
-  const locationParagraph = document.createElement('p');
-  locationParagraph.appendChild(locationLinkEl);
+// Create link to item
+const locationLinkEl = document.createElement('a');
+locationLinkEl.href = locationLink;
+locationLinkEl.textContent = 'View Item';
+locationLinkEl.target = '_blank';
+locationLinkEl.className = 'card-link';
+cardLinks.appendChild(locationLinkEl);
 
-  // Create link to IIIF manifest
-  const manifestLinkEl = document.createElement('a');
-  manifestLinkEl.href = manifest['@id'] || manifest.id || '#';
-  manifestLinkEl.textContent = 'View IIIF Manifest';
-  manifestLinkEl.target = '_blank';
+// Create link to IIIF manifest
+const manifestLinkEl = document.createElement('a');
+manifestLinkEl.href = manifest['@id'] || manifest.id || '#';
+manifestLinkEl.textContent = 'View Manifest';
+manifestLinkEl.target = '_blank';
+manifestLinkEl.className = 'card-link';
+cardLinks.appendChild(manifestLinkEl);
 
-  const manifestParagraph = document.createElement('p');
-  manifestParagraph.appendChild(manifestLinkEl);
-
-  // Create link to Allmaps
-  const allmapsLinkEl = document.createElement('a');
-  allmapsLinkEl.href = allmapsLink;
-  allmapsLinkEl.textContent = 'Open in Allmaps Editor';
-  allmapsLinkEl.target = '_blank';
-
-  const allmapsParagraph = document.createElement('p');
-  allmapsParagraph.appendChild(allmapsLinkEl);
+// Create link to Allmaps
+const allmapsLinkEl = document.createElement('a');
+allmapsLinkEl.href = allmapsLink;
+allmapsLinkEl.textContent = 'Allmaps Editor';
+allmapsLinkEl.target = '_blank';
+allmapsLinkEl.className = 'card-link';
+cardLinks.appendChild(allmapsLinkEl);
 
   // Append all elements to card
   card.appendChild(deleteBtn);
@@ -602,9 +603,7 @@ if (!locationLink) {
   card.appendChild(dateEl);
   card.appendChild(collectionEl);
   card.appendChild(attributionEl);
-  card.appendChild(locationParagraph);
-  card.appendChild(manifestParagraph);
-  card.appendChild(allmapsParagraph);
+  card.appendChild(cardLinks);
 
   // Add card to gallery
   document.getElementById('gallery').appendChild(card);

--- a/styles.css
+++ b/styles.css
@@ -327,6 +327,34 @@ body {
   background: grey;
 }
 
+/* Card links (styled like control links) */
+.card-links {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 3px;
+  margin-top: 8px;
+  padding-top: 8px;
+  border-top: 1px solid #e0e0e0;
+}
+
+.card-links .card-link {
+  font-family: 'Open Sans', sans-serif;
+  font-size: 10px;
+  font-weight: 600;
+  color: #666 !important; /* Override .card a color */
+  text-decoration: none !important;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  transition: color 0.2s ease;
+  cursor: pointer;
+}
+
+.card-links .card-link:hover {
+  color: #0073A3 !important; /* Override .card a:hover color */
+  text-decoration: none !important;
+}
+
 /* Resizable divider */
 #resizer {
   width: 5px;


### PR DESCRIPTION
Card link styling improvements:

- Replaced individual paragraph-wrapped links with grouped link container
- Styled card links to match header control links (uppercase, grey, compact)
- Changed link layout from stacked paragraphs to flex column container
- Added subtle top border to separate links from metadata
- Reduced font size to 10px for more compact appearance
- Links now grey (#666) by default, turn blue (#0073A3) on hover
- Shortened link text ("View Manifest" instead of "View IIIF Manifest")
- Used !important to override existing .card a styles for proper color display
- Improved visual hierarchy with grouped, consistently styled action links

Visual changes:
- Links now appear as compact, uppercase text at bottom of card
- Separated from metadata with thin horizontal line
- Consistent styling across all cards
- Matches overall app design language