### PR TITLE
Switch CORS proxy to AllOrigins for better reliability

### DIFF
--- a/script.js
+++ b/script.js
@@ -750,12 +750,12 @@ async function addManifestToGallery(manifestUrl) {
     
     if (needsProxy) {
       // Use CORS proxy
-      fetchUrl = `https://corsproxy.io/?${encodeURIComponent(manifestUrl)}`;
+      fetchUrl = `https://api.allorigins.win/raw?url=${encodeURIComponent(manifestUrl)}`;
       console.log('Using CORS proxy for:', manifestUrl);
     }
 
     const response = await fetch(fetchUrl);
-    
+
     if (!response.ok) {
       throw new Error(`Network response was not ok: ${response.statusText}`);
     }


### PR DESCRIPTION
corsproxy.io returned 403 Forbidden for LOC requests. Switched to api.allorigins.win which has better uptime and higher rate limits.